### PR TITLE
Add support for trigger temps (low/high) and fix crash when bytearray is smaller than expected)

### DIFF
--- a/src/ac_infinity_ble/device.py
+++ b/src/ac_infinity_ble/device.py
@@ -221,6 +221,18 @@ class ACInfinityController:
         await self._send_command(command)
         await self._execute_disconnect()
 
+    async def set_type(self, type: int) -> None:
+        """Set the work type of the controller."""
+        await self._ensure_connected()
+        _LOGGER.debug("%s: Set type to %s", self.name, type)
+        self._state.work_type = type
+
+        command = self._protocol.set_level(
+            self._state.type, self._state.work_type, self._state.fan, 0, self.sequence
+        )
+        await self._send_command(command)
+        await self._execute_disconnect()
+
     async def stop(self) -> None:
         """Stop the controller."""
         _LOGGER.debug("%s: Stop", self.name)

--- a/src/ac_infinity_ble/models.py
+++ b/src/ac_infinity_ble/models.py
@@ -14,6 +14,8 @@ class DeviceInfo:
     vpd_state: int | None = None
     choose_port: int | None = None
     tmp: float | None = None
+    tmp_trigger_low: int | None = None
+    tmp_trigger_high: int | None = None
     hum: float | None = None
     vpd: float | None = None
     fan_type: int | None = None

--- a/src/ac_infinity_ble/protocol.py
+++ b/src/ac_infinity_ble/protocol.py
@@ -100,8 +100,10 @@ class Protocol:
     def set_level(
         self, type: int, work_type: int, level: int, b: int, sequence: int
     ) -> bytes:
-        if work_type not in [1, 2]:
-            raise ValueError("Work type must be 1 (off) or 2 (on)")
+        if work_type not in [1, 2, 3, 4, 6]:
+            raise ValueError(
+                "Work type must be 1 (off), 2 (on), 3 (auto), 4 (timer), or 6 (cycle)"
+            )
         if level not in range(0, 11):
             raise ValueError("Level must be between 0 and 10")
 


### PR DESCRIPTION
Hi. I recently stumbled upon your HASS integration (and the corresponding python lib) and happen to have one of AC Infinity's Smart Vents installed in my home.

I have two PRs to submit, one for the ble library and one for the HASS integration.

ac-infinity-ble changes:
- Check bytearray size when assigning states. Not all devices expose the same size payloads
- Add support for temperature trigger low and high

ac-infinity-hacs 
- Add support for AIRTAP T6 Smart Vent
- Only expose sensors if a device model supports it 
- Add sensors for temperature trigger low and high

I think I will need to wait to submit a PR for the HASS integration until this library is revved with these changes, if you are willing to accept them.

Thank you!